### PR TITLE
added include that it works with latest opencv on ubuntu 20.04

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -7,6 +7,7 @@
 #include <image_transport/image_transport.h>
 
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/calib3d.hpp>
 
 #include "node.h"
 #include "names.h"


### PR DESCRIPTION
tried to compile under Ubuntu 20.04 with latest libopencv-dev python3-opencv at time (20.03.2023)

got error: ‘Rodrigues’ is not a member of ‘cv’

Fix: add #include <opencv2/calib3d.hpp> in node.cpp
